### PR TITLE
create separate DASH/HLS manifests for 8k, 4k, 1080p, 720p, SD

### DIFF
--- a/byoda/data_import/youtube_format.py
+++ b/byoda/data_import/youtube_format.py
@@ -1,0 +1,182 @@
+'''
+Model a Youtube video/audio/storyboard etc. format
+
+:maintainer : Steven Hessing <steven@byoda.org>
+:copyright  : Copyright 2021, 2022, 2023, 2024
+:license    : GPLv3
+'''
+
+from typing import Self
+
+
+class YouTubeFragment:
+    '''
+    Models a fragment of a YouTube video or audio track
+    '''
+
+    def __init__(self) -> None:
+        self.url: str | None = None
+        self.duration: float | None = None
+        self.path: str | None = None
+
+    def as_dict(self) -> dict[str, str | float]:
+        '''
+        Returns a dict representation of the fragment
+        '''
+
+        return {
+            'url': self.url,
+            'duration': self.duration,
+            'path': self.path
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, str | float]) -> Self:
+        '''
+        Factory for YouTubeFragment, parses data are provided
+        by yt-dlp
+        '''
+
+        fragment = YouTubeFragment()
+        fragment.url = data.get('url')
+        fragment.path = data.get('path')
+        fragment.duration = data.get('duration')
+        return fragment
+
+
+class YouTubeFormat:
+    '''
+    Models a track (audio, video, or storyboard of YouTube video
+    '''
+
+    def __init__(self) -> None:
+        self.format_id: str | None = None
+        self.format_note: str | None = None
+        self.ext: str | None = None
+        self.audio_ext: str | None = None
+        self.video_ext: str | None = None
+        self.protocol: str | None = None
+        self.audio_codec: str | None = None
+        self.video_codec: str | None = None
+        self.container: str | None = None
+        self.url: str | None = None
+        self.width: int | None = None
+        self.height: int | None = None
+        self.fps: float | None = None
+        self.quality: float | None = None
+        self.dynamic_range: str | None = None
+        self.has_drm: bool | None = None
+        self.tbr: float | None = None
+        self.abr: float | None = None
+        self.asr: int | None = None
+        self.audio_channels: int | None = None
+        self.rows: int | None = None
+        self.cols: int | None = None
+        self.fragments: list[YouTubeFragment] = []
+        self.resolution: str | None = None
+        self.aspect_ratio: str | None = None
+        self.format: str | None = None
+
+    def __str__(self) -> str:
+        return (
+            f'YouTubeFormat('
+            f'{self.format_id}, {self.format_note}, {self.ext}, '
+            f'{self.protocol}, {self.audio_codec}, {self.video_codec}, '
+            f'{self.container}, {self.width}, {self.height}, {self.fps}, '
+            f'{self.resolution}, '
+            f'{self.audio_ext}, {self.video_ext}'
+            ')'
+        )
+
+    def as_dict(self) -> dict[str, any]:
+        '''
+        Returns a dict representation of the video
+        '''
+
+        data: dict[str, any] = {
+            'format_id': self.format_id,
+            'format_note': self.format_note,
+            'ext': self.ext,
+            'audio_ext': self.audio_ext,
+            'video_ext': self.video_ext,
+            'protocol': self.protocol,
+            'audio_codec': self.audio_codec,
+            'video_codec': self.video_codec,
+            'container': self.container,
+            'url': self.url,
+            'width': self.width,
+            'height': self.height,
+            'fps': self.fps,
+            'quality': self.quality,
+            'dynamic_range': self.dynamic_range,
+            'has_drm': self.has_drm,
+            'tbr': self.tbr,
+            'abr': self.abr,
+            'asr': self.asr,
+            'audio_channels': self.audio_channels,
+            'rows': self.rows,
+            'cols': self.cols,
+            'fragments': [],
+            'resolution': self.resolution,
+            'aspect_ratio': self.aspect_ratio,
+            'format': self.format,
+        }
+
+        for fragment in self.fragments:
+            data['fragments'].append(fragment.as_dict())
+
+        return data
+
+    def from_dict(data: dict[str, any]) -> Self:
+        '''
+        Factory using data retrieved using the 'yt-dlp' tool
+        '''
+
+        format = YouTubeFormat()
+        format.format_id = data['format_id']
+        format.format_note = data.get('format_note')
+        format.ext = data.get('ext')
+        format.protocol = data.get('protocol')
+        format.audio_codec = data.get('acodec')
+        if format.audio_codec and format.audio_codec.lower() == 'none':
+            format.audio_codec = None
+
+        format.video_codec = data.get('vcodec')
+        if format.video_codec and format.video_codec.lower() == 'none':
+            format.video_codec = None
+
+        format.container = data.get('container')
+        format.audio_ext = data.get('audio_ext')
+        format.video_ext = data.get('video_ext')
+        format.url = data.get('url')
+        format.width = data.get('width')
+        format.height = data.get('height')
+        format.fps = data.get('fps')
+        format.tbr = data.get('tbr')
+        format.asr = data.get('asr')
+        format.abr = data.get('abr')
+        format.rows = data.get('rows')
+        format.cols = data.get('cols')
+        format.audio_channels = data.get('audio_channels')
+        format.dynamic_range = data.get('dynamic_range')
+
+        format.resolution = data.get('resolution')
+        format.aspect_ratio = data.get('aspect_ratio')
+        format.audio_ext = data.get('audio_ext')
+        format.video_ext = data.get('video_ext')
+        format.format = data.get('format')
+
+        for fragment_data in data.get('fragments', []):
+            fragment: YouTubeFragment = YouTubeFragment.from_dict(
+                fragment_data
+            )
+            format.fragments.append(fragment)
+
+        return format
+
+    def get_filename(self, video_id: str) -> str:
+        '''
+        Returns the filename of the video
+        '''
+
+        return f'{self.format_id}.{self.ext}'

--- a/byoda/data_import/youtube_streams.py
+++ b/byoda/data_import/youtube_streams.py
@@ -8,49 +8,82 @@ Definitions for the tracks containing audio and video of a Youtube video
 
 # flake8: noqa: E501
 
+from enum import Enum
+from typing import Self
+
+
+
+class EncodingCategory(Enum):
+    '''
+    We use numbering so that we can include all tracks with category <= 3
+    for an upto and including HD manifest
+    '''
+    SD          = 1
+    SEVENTWENTY = 2
+    TENEIGHTY   = 3
+    FOURK       = 4
+    EIGHTK      = 5
+
+    def __lt__(self, other: Self) -> bool:
+        return self.value < other.value
+
+    def label(self) -> str:
+        if self == EncodingCategory.SD:
+            return 'SD'
+        elif self == EncodingCategory.SEVENTWENTY:
+            return '720p'
+        elif self == EncodingCategory.TENEIGHTY:
+            return '1080p'
+        elif self == EncodingCategory.FOURK:
+            return '4K'
+        elif self == EncodingCategory.EIGHTK:
+            return '8K'
+        else:
+            return 'Unknown'
+
 # These are the MPEG-DASH AV1 and H.264 streams that we want to download. We
 # try to download streams that have 'wanted' == True. If a video does not
 # have one of the wanted streams, then we will try to download the replacement.
 # We are currently not attempting to download 8k streams
 TARGET_VIDEO_STREAMS: dict[str, dict[str, str | bool |  None]] = {
-    '701': {'resolution': '2160p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '401'},
-    '700': {'resolution': '1440p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '400'},
-    '699': {'resolution': '1080p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '399'},
-    '698': {'resolution': '720p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '398'},
-    '697': {'resolution': '480p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '397'},
-    '696': {'resolution': '360p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '396'},
-    '695': {'resolution': '240p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '395'},
-    '694': {'resolution': '144p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '394'},
-    '398': {'resolution': '720p', 'codec': 'AV1 HFR', 'wanted': True, 'replacement': '298'},
-    '402': {'resolution': '4320p', 'codec': 'AV1 HFR', 'wanted': False, 'replacement': None},
-    '571': {'resolution': '4320p', 'codec': 'AV1 HFR', 'wanted': False, 'replacement': None},
-    '401': {'resolution': '2160p', 'codec': 'AV1 HFR', 'wanted': True, 'replacement': '305'},
-    '400': {'resolution': '1440p', 'codec': 'AV1 HFR', 'wanted': True, 'replacement': '304'},
-    '399': {'resolution': '1080p', 'codec': 'AV1 HFR', 'wanted': True, 'replacement': '299'},
-    '397': {'resolution': '480p', 'codec': 'AV1', 'wanted': True, 'replacement': '135'},
-    '396': {'resolution': '360p', 'codec': 'AV1', 'wanted': True, 'replacement': '134'},
-    '395': {'resolution': '240p', 'codec': 'AV1', 'wanted': True, 'replacement': '133'},
-    '394': {'resolution': '144p', 'codec': 'AV1', 'wanted': True, 'replacement': '160'},
-    '305': {'resolution': '2160p', 'codec': 'H.264 HFR', 'wanted': True, 'replacement': '266'},
-    '304': {'resolution': '1440p', 'codec': 'H.264 HFR', 'wanted': True, 'replacement': '264'},
-    '299': {'resolution': '1080p', 'codec': 'H.264 HFR', 'wanted': True, 'replacement': '137'},
-    '298': {'resolution': '720p', 'codec': 'H.264 HFR', 'wanted': True, 'replacement': '136'},
-    '266': {'resolution': '2160p', 'codec': 'H.264', 'wanted': True, 'replacement': None},
-    '264': {'resolution': '1440p', 'codec': 'H.264', 'wanted': True, 'replacement': None},
-    '137': {'resolution': '1080p', 'codec': 'H.264', 'wanted': True, 'replacement': None},
-    '136': {'resolution': '720p', 'codec': 'H.264', 'wanted': True, 'replacement': None},
-    '135': {'resolution': '480p', 'codec': 'H.264', 'wanted': True, 'replacement': None},
-    '134': {'resolution': '360p', 'codec': 'H.264', 'wanted': True, 'replacement': None},
-    '133': {'resolution': '240p', 'codec': 'H.264', 'wanted': True, 'replacement': None},
-    '160': {'resolution': '144p', 'codec': 'H.264', 'wanted': True, 'replacement': None},
+    '701': {'resolution': '2160p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '401', 'category': EncodingCategory.FOURK},
+    '700': {'resolution': '1440p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '400', 'category': EncodingCategory.FOURK},
+    '699': {'resolution': '1080p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '399', 'category': EncodingCategory.TENEIGHTY},
+    '698': {'resolution': '720p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '398', 'category': EncodingCategory.SEVENTWENTY},
+    '697': {'resolution': '480p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '397', 'category': EncodingCategory.SD},
+    '696': {'resolution': '360p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '396', 'category': EncodingCategory.SD},
+    '695': {'resolution': '240p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '395', 'category': EncodingCategory.SD},
+    '694': {'resolution': '144p', 'codec': 'AV1 HFR High', 'wanted': True, 'replacement': '394', 'category': EncodingCategory.SD},
+    '398': {'resolution': '720p', 'codec': 'AV1 HFR', 'wanted': True, 'replacement': '298', 'category': EncodingCategory.SEVENTWENTY},
+    '402': {'resolution': '4320p', 'codec': 'AV1 HFR', 'wanted': False, 'replacement': None, 'category': EncodingCategory.EIGHTK},
+    '571': {'resolution': '4320p', 'codec': 'AV1 HFR', 'wanted': False, 'replacement': None, 'category': EncodingCategory.EIGHTK},
+    '401': {'resolution': '2160p', 'codec': 'AV1 HFR', 'wanted': True, 'replacement': '305', 'category': EncodingCategory.FOURK},
+    '400': {'resolution': '1440p', 'codec': 'AV1 HFR', 'wanted': True, 'replacement': '304', 'category': EncodingCategory.FOURK},
+    '399': {'resolution': '1080p', 'codec': 'AV1 HFR', 'wanted': True, 'replacement': '299', 'category': EncodingCategory.TENEIGHTY},
+    '397': {'resolution': '480p', 'codec': 'AV1', 'wanted': True, 'replacement': '135', 'category': EncodingCategory.SD},
+    '396': {'resolution': '360p', 'codec': 'AV1', 'wanted': True, 'replacement': '134', 'category': EncodingCategory.SD},
+    '395': {'resolution': '240p', 'codec': 'AV1', 'wanted': True, 'replacement': '133', 'category': EncodingCategory.SD},
+    '394': {'resolution': '144p', 'codec': 'AV1', 'wanted': True, 'replacement': '160', 'category': EncodingCategory.SD},
+    '305': {'resolution': '2160p', 'codec': 'H.264 HFR', 'wanted': True, 'replacement': '266', 'category': EncodingCategory.FOURK},
+    '304': {'resolution': '1440p', 'codec': 'H.264 HFR', 'wanted': True, 'replacement': '264', 'category': EncodingCategory.FOURK},
+    '299': {'resolution': '1080p', 'codec': 'H.264 HFR', 'wanted': True, 'replacement': '137', 'category': EncodingCategory.TENEIGHTY},
+    '298': {'resolution': '720p', 'codec': 'H.264 HFR', 'wanted': True, 'replacement': '136', 'category': EncodingCategory.SEVENTWENTY},
+    '266': {'resolution': '2160p', 'codec': 'H.264', 'wanted': True, 'replacement': None, 'category': EncodingCategory.FOURK},
+    '264': {'resolution': '1440p', 'codec': 'H.264', 'wanted': True, 'replacement': None, 'category': EncodingCategory.FOURK},
+    '137': {'resolution': '1080p', 'codec': 'H.264', 'wanted': True, 'replacement': None, 'category': EncodingCategory.TENEIGHTY},
+    '136': {'resolution': '720p', 'codec': 'H.264', 'wanted': True, 'replacement': None, 'category': EncodingCategory.SEVENTWENTY},
+    '135': {'resolution': '480p', 'codec': 'H.264', 'wanted': True, 'replacement': None, 'category': EncodingCategory.SD},
+    '134': {'resolution': '360p', 'codec': 'H.264', 'wanted': True, 'replacement': None, 'category': EncodingCategory.SD},
+    '133': {'resolution': '240p', 'codec': 'H.264', 'wanted': True, 'replacement': None, 'category': EncodingCategory.SD},
+    '160': {'resolution': '144p', 'codec': 'H.264', 'wanted': True, 'replacement': None, 'category': EncodingCategory.SD},
 }
 
 # These are the MPEG-DASH MP4 audio streams that we want to download.
 TARGET_AUDIO_STREAMS: dict[str, dict[str, str | bool |  None]] = {
-    '599': {'codec': 'mp4a HE v1 32kbps', 'wanted': True, 'replacement': None},
-    '139': {'codec': 'mp4a HE v1 48kbps', 'wanted': True, 'replacement': None},
-    '140': {'codec': 'mp4a AAC-LC 128kbps', 'wanted': True, 'replacement': None},
-    '141': {'codec': 'mp4a AAC-LC 256kbps', 'wanted': True, 'replacement': None},
+    '599': {'codec': 'mp4a HE v1 32kbps', 'wanted': True, 'replacement': None, 'category': EncodingCategory.SD},
+    '139': {'codec': 'mp4a HE v1 48kbps', 'wanted': True, 'replacement': None, 'category': EncodingCategory.SD},
+    '140': {'codec': 'mp4a AAC-LC 128kbps', 'wanted': True, 'replacement': None, 'category': EncodingCategory.TENEIGHTY},
+    '141': {'codec': 'mp4a AAC-LC 256kbps', 'wanted': True, 'replacement': None, 'category': EncodingCategory.FOURK},
 }
 
 # We are not interested in formats:

--- a/byoda/util/api_client/api_client.py
+++ b/byoda/util/api_client/api_client.py
@@ -319,7 +319,7 @@ class ApiClient:
         if not data:
             processed_data: bytes | str | None = None
         elif type(data) not in [str, bytes]:
-            # orjson can serialize datetimes, UUIDs so we serialize
+            # orjson can serialize datetimes & UUIDs so we serialize
             # ourselves instead of having the HTTP client library do it
             processed_data = orjson.dumps(data)
         else:


### PR DESCRIPTION
Create separate DASH/HLS manifests for 8K, 4K, 1080p, 720p and SD.
The manifests include all bitrates up to and including the specified resolution
Manifests are available by taking the video_url, strip off trailing '.mpd', appending the max encoding resolution, and re-appending '.mpd' (or '.hls' for the HLS manifest)
